### PR TITLE
feat: basic activity tracking

### DIFF
--- a/src/__tests__/distance.test.ts
+++ b/src/__tests__/distance.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest';
+import { haversineDistance } from '../activity/distance';
+
+const p = (latitude: number, longitude: number) => ({ latitude, longitude });
+
+test('zero distance for identical points', () => {
+  expect(haversineDistance(p(0, 0), p(0, 0))).toBe(0);
+});
+
+test('distance of 1 degree longitude at equator ~111.32km', () => {
+  const d = haversineDistance(p(0, 0), p(0, 1));
+  expect(d).toBeGreaterThan(111);
+  expect(d).toBeLessThan(112);
+});

--- a/src/__tests__/sessionReducer.test.ts
+++ b/src/__tests__/sessionReducer.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from 'vitest';
+import {
+  initialSessionState,
+  sessionReducer,
+  SessionState,
+} from '../activity/session';
+import { LocationSample } from '../db';
+
+function sample(
+  latitude: number,
+  longitude: number,
+  timestamp: number,
+): LocationSample {
+  return {
+    timestamp,
+    location: { latitude, longitude, accuracy: 5 },
+  };
+}
+
+test('start and add samples accumulate distance and duration', () => {
+  let state: SessionState = sessionReducer(initialSessionState, {
+    type: 'start',
+    timestamp: 0,
+  });
+  state = sessionReducer(state, {
+    type: 'addSample',
+    sample: sample(0, 0, 0),
+  });
+  state = sessionReducer(state, {
+    type: 'addSample',
+    sample: sample(0, 1, 1000),
+  });
+  expect(state.distance).toBeGreaterThan(111);
+  expect(state.duration).toBe(1);
+});
+
+test('pause and resume change status', () => {
+  let state = sessionReducer(initialSessionState, { type: 'start', timestamp: 0 });
+  state = sessionReducer(state, { type: 'pause', timestamp: 1000 });
+  expect(state.status).toBe('paused');
+  state = sessionReducer(state, { type: 'resume', timestamp: 2000 });
+  expect(state.status).toBe('running');
+});
+
+test('stop finalizes duration', () => {
+  let state = sessionReducer(initialSessionState, { type: 'start', timestamp: 0 });
+  state = sessionReducer(state, {
+    type: 'addSample',
+    sample: sample(0, 0, 0),
+  });
+  state = sessionReducer(state, { type: 'stop', timestamp: 5000 });
+  expect(state.status).toBe('stopped');
+  expect(state.duration).toBe(5);
+});

--- a/src/activity/distance.ts
+++ b/src/activity/distance.ts
@@ -1,0 +1,21 @@
+export interface LatLng {
+  latitude: number;
+  longitude: number;
+}
+
+const R = 6371; // Earth radius in km
+
+function toRad(deg: number) {
+  return (deg * Math.PI) / 180;
+}
+
+export function haversineDistance(a: LatLng, b: LatLng): number {
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLon = toRad(b.longitude - a.longitude);
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.sin(dLon / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+  return 2 * R * Math.asin(Math.sqrt(h));
+}

--- a/src/activity/session.ts
+++ b/src/activity/session.ts
@@ -1,0 +1,95 @@
+import { LocationSample } from '../db';
+import { haversineDistance } from './distance';
+
+export interface SessionState {
+  status: 'idle' | 'running' | 'paused' | 'stopped';
+  samples: LocationSample[];
+  distance: number; // kilometers
+  duration: number; // seconds
+  startedAt?: number;
+  lastTimestamp?: number;
+  pausedAt?: number;
+  pausedMs: number;
+}
+
+export type SessionAction =
+  | { type: 'start'; timestamp: number }
+  | { type: 'addSample'; sample: LocationSample }
+  | { type: 'pause'; timestamp: number }
+  | { type: 'resume'; timestamp: number }
+  | { type: 'stop'; timestamp: number };
+
+export const initialSessionState: SessionState = {
+  status: 'idle',
+  samples: [],
+  distance: 0,
+  duration: 0,
+  pausedMs: 0,
+};
+
+export function sessionReducer(
+  state: SessionState,
+  action: SessionAction,
+): SessionState {
+  switch (action.type) {
+    case 'start':
+      return {
+        status: 'running',
+        samples: [],
+        distance: 0,
+        duration: 0,
+        startedAt: action.timestamp,
+        lastTimestamp: action.timestamp,
+        pausedMs: 0,
+      };
+    case 'addSample': {
+      if (state.status !== 'running') return state;
+      const samples = [...state.samples, action.sample];
+      const prev = state.samples[state.samples.length - 1];
+      const additional = prev
+        ? haversineDistance(prev.location, action.sample.location)
+        : 0;
+      const lastTimestamp = action.sample.timestamp;
+      const duration = state.startedAt !== undefined
+        ? Math.round((lastTimestamp - state.startedAt - state.pausedMs) / 1000)
+        : state.duration;
+      return {
+        ...state,
+        samples,
+        distance: state.distance + additional,
+        lastTimestamp,
+        duration,
+      };
+    }
+    case 'pause':
+      if (state.status !== 'running') return state;
+      return { ...state, status: 'paused', pausedAt: action.timestamp };
+    case 'resume': {
+      if (state.status !== 'paused') return state;
+      const pausedMs =
+        state.pausedMs +
+        (state.pausedAt ? action.timestamp - state.pausedAt : 0);
+      return { ...state, status: 'running', pausedAt: undefined, pausedMs };
+    }
+    case 'stop': {
+      if (state.status === 'idle' || state.status === 'stopped') return state;
+      const pausedMs =
+        state.pausedMs +
+        (state.status === 'paused' && state.pausedAt
+          ? action.timestamp - state.pausedAt
+          : 0);
+      const duration = state.startedAt !== undefined
+        ? Math.round((action.timestamp - state.startedAt - pausedMs) / 1000)
+        : state.duration;
+      return {
+        ...state,
+        status: 'stopped',
+        duration,
+        lastTimestamp: action.timestamp,
+        pausedMs,
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/src/routes/Activity.tsx
+++ b/src/routes/Activity.tsx
@@ -1,3 +1,150 @@
+import { useReducer, useRef, useEffect } from 'react';
+import {
+  initialSessionState,
+  sessionReducer,
+} from '../activity/session';
+import { db, Activity as ActivityRecord } from '../db';
+import { enqueueMutation } from '../sync';
+
 export default function Activity() {
-  return <div className="p-4">Activity Page</div>;
+  const [state, dispatch] = useReducer(sessionReducer, initialSessionState);
+  const watchId = useRef<number | null>(null);
+  const wakeLock = useRef<WakeLockSentinel | null>(null);
+
+  useEffect(() => {
+    if (state.status === 'running' && watchId.current == null) {
+      if ('geolocation' in navigator) {
+        watchId.current = navigator.geolocation.watchPosition(
+          (pos) => {
+            dispatch({
+              type: 'addSample',
+              sample: {
+                timestamp: pos.timestamp,
+                location: {
+                  latitude: pos.coords.latitude,
+                  longitude: pos.coords.longitude,
+                  accuracy: pos.coords.accuracy,
+                },
+              },
+            });
+          },
+          () => {},
+          { enableHighAccuracy: true },
+        );
+      }
+    }
+    if (state.status !== 'running' && watchId.current != null) {
+      navigator.geolocation.clearWatch(watchId.current);
+      watchId.current = null;
+    }
+    return () => {
+      if (watchId.current != null) {
+        navigator.geolocation.clearWatch(watchId.current);
+        watchId.current = null;
+      }
+    };
+  }, [state.status]);
+
+  useEffect(() => {
+    async function requestLock() {
+      if (state.status === 'running' && 'wakeLock' in navigator) {
+        try {
+          const nav = navigator as Navigator & { wakeLock?: { request(type: 'screen'): Promise<WakeLockSentinel> } };
+          wakeLock.current = await nav.wakeLock?.request('screen');
+          wakeLock.current?.addEventListener('release', () => {
+            wakeLock.current = null;
+          });
+        } catch {
+          // ignore
+        }
+      }
+    }
+    requestLock();
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        requestLock();
+      } else {
+        wakeLock.current?.release();
+        wakeLock.current = null;
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      wakeLock.current?.release();
+      wakeLock.current = null;
+    };
+  }, [state.status]);
+
+  const start = () => dispatch({ type: 'start', timestamp: Date.now() });
+  const pause = () => dispatch({ type: 'pause', timestamp: Date.now() });
+  const resume = () => dispatch({ type: 'resume', timestamp: Date.now() });
+  const stop = async () => {
+    const timestamp = Date.now();
+    const finalState = sessionReducer(state, { type: 'stop', timestamp });
+    dispatch({ type: 'stop', timestamp });
+    if (watchId.current != null) {
+      navigator.geolocation.clearWatch(watchId.current);
+      watchId.current = null;
+    }
+    wakeLock.current?.release();
+    wakeLock.current = null;
+
+    const activity: ActivityRecord = {
+      id: crypto.randomUUID(),
+      userId: 'local-user',
+      kind: 'walk',
+      distanceKm: finalState.distance,
+      durationSec: finalState.duration,
+      steps: 0,
+      samples: finalState.samples,
+      startedAt: new Date(finalState.startedAt ?? timestamp).toISOString(),
+      endedAt: new Date(timestamp).toISOString(),
+      updatedAt: new Date(timestamp).toISOString(),
+      clientTag: crypto.randomUUID(),
+    };
+    await db.activities.add(activity);
+    await enqueueMutation({
+      entity: 'activity',
+      operation: 'create',
+      payload: activity,
+    });
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div>Distance: {state.distance.toFixed(2)} km</div>
+      <div>Duration: {state.duration}s</div>
+      {state.status === 'idle' && (
+        <button className="btn" onClick={start}>
+          Start
+        </button>
+      )}
+      {state.status === 'running' && (
+        <div className="space-x-2">
+          <button className="btn" onClick={pause}>
+            Pause
+          </button>
+          <button className="btn" onClick={stop}>
+            Stop
+          </button>
+        </div>
+      )}
+      {state.status === 'paused' && (
+        <div className="space-x-2">
+          <button className="btn" onClick={resume}>
+            Resume
+          </button>
+          <button className="btn" onClick={stop}>
+            Stop
+          </button>
+        </div>
+      )}
+      {state.status === 'stopped' && (
+        <button className="btn" onClick={start}>
+          Restart
+        </button>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add Haversine utility and session reducer for activity tracking
- implement Activity screen with geolocation sampling, pause/resume, and offline saving
- test distance calculations and session reducer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5a69782c883209116de512263efbf