### PR TITLE
fix: avoid runtime import of Dexie Table

### DIFF
--- a/src/activity/session.ts
+++ b/src/activity/session.ts
@@ -1,4 +1,4 @@
-import { LocationSample } from '../db';
+import type { LocationSample } from '../db';
 import { haversineDistance } from './distance';
 
 export interface SessionState {

--- a/src/auth/tokenManager.ts
+++ b/src/auth/tokenManager.ts
@@ -9,18 +9,24 @@ export interface TokenSet {
 
 const STORAGE_KEY = 'authTokens';
 
+interface NodeBuffer {
+  from(data: string, encoding: string): { toString(encoding: string): string };
+}
+
 function encode(data: string): string {
   if (typeof btoa !== 'undefined') {
     return btoa(data);
   }
-  return Buffer.from(data, 'utf-8').toString('base64');
+  const buffer = (globalThis as unknown as { Buffer: NodeBuffer }).Buffer;
+  return buffer.from(data, 'utf-8').toString('base64');
 }
 
 function decode(data: string): string {
   if (typeof atob !== 'undefined') {
     return atob(data);
   }
-  return Buffer.from(data, 'base64').toString('utf-8');
+  const buffer = (globalThis as unknown as { Buffer: NodeBuffer }).Buffer;
+  return buffer.from(data, 'base64').toString('utf-8');
 }
 
 export class TokenManager {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,4 @@
-import Dexie, { Table } from 'dexie';
+import Dexie, { type Table } from 'dexie';
 
 export interface Meal {
   id: string;

--- a/src/routes/Activity.tsx
+++ b/src/routes/Activity.tsx
@@ -3,7 +3,7 @@ import {
   initialSessionState,
   sessionReducer,
 } from '../activity/session';
-import { db, Activity as ActivityRecord } from '../db';
+import { db, type Activity as ActivityRecord } from '../db';
 import { enqueueMutation } from '../sync';
 
 export default function Activity() {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -7,6 +7,10 @@ import { replayMutations } from './sync';
 
 declare let self: ServiceWorkerGlobalScope;
 
+interface SyncEvent extends ExtendableEvent {
+  tag: string;
+}
+
 clientsClaim();
 precacheAndRoute(self.__WB_MANIFEST);
 
@@ -31,7 +35,8 @@ self.addEventListener('fetch', (event) => {
 });
 
 self.addEventListener('sync', (event) => {
-  if (event.tag === 'sync-mutations') {
-    event.waitUntil(replayMutations());
+  const syncEvent = event as SyncEvent;
+  if (syncEvent.tag === 'sync-mutations') {
+    syncEvent.waitUntil(replayMutations());
   }
 });

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,4 +1,4 @@
-import { db, AppDB, Mutation, MutationEntity, MutationOperation } from './db';
+import { db, type AppDB, type Mutation, type MutationEntity, type MutationOperation } from './db';
 
 export async function enqueueMutation(
   mutation: { entity: MutationEntity; operation: MutationOperation; payload: unknown },
@@ -26,7 +26,9 @@ export async function registerSync(tag = 'sync-mutations') {
   }
   const reg = await navigator.serviceWorker.ready;
   try {
-    await reg.sync.register(tag);
+    await (reg as ServiceWorkerRegistration & {
+      sync: { register(tag: string): Promise<void> };
+    }).sync.register(tag);
   } catch {
     // ignore
   }


### PR DESCRIPTION
## Summary
- import Dexie's `Table` as a type to prevent runtime module export error
- convert other shared types to type-only imports and add typing for service worker sync events
- polyfill token encoding/decoding without relying on Node's `Buffer` type

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5bbd48c4c83209075e926a49f306a