### PR TITLE
Fix client tests by resolving local openauth-js module

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
+import path from 'node:path';
 
 export default defineConfig({
   plugins: [
@@ -23,6 +24,11 @@ export default defineConfig({
       },
     }),
   ],
+  resolve: {
+    alias: {
+      'openauth-js': path.resolve(__dirname, 'openauth-js'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- Resolve `openauth-js` using a Vite alias so client code can load the bundled auth helpers

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68c5e705ce8883209d4a4e4c03b8aa5c